### PR TITLE
Add Dockerfile with container description and tests using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python # support for pip, used to install ncclient
+sudo: required
+services:
+  - docker
+before_install:
+  - pip install ncclient
+  - ssh-keygen -N '' -f $HOME/.ssh/id_rsa
+script:
+  - docker build -t netopeer .
+  - docker run -d -p 8300:830 --name netopeer netopeer
+  - while ! docker logs netopeer 2>&1 | grep 'Netopeer server successfully initialized'; do echo '***** init string not found'; sleep 1; done
+  - sleep 5
+  - python -c "from ncclient import manager; m = manager.connect(host='127.0.0.1', port=8300, hostkey_verify=False); print(m.get())"
+  - docker logs netopeer
+  - docker stop netopeer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos
+
+# install required packages
+RUN ["yum", "install", "-y", "epel-release"]
+RUN ["yum", "install", "-y", "git", "make", "libtool", "libxml2-devel", "file", "libxslt-devel", "libssh-devel", "libcurl-devel", "python-pip", "libxml2-python", "openssh-server" ]
+RUN ["ssh-keygen", "-A"]
+RUN ["pip", "install", "pyang"]
+
+# clone, build and install libnetconf
+RUN set -e -x; \
+    git clone https://github.com/CESNET/libnetconf.git /usr/src/libnetconf; \
+    cd /usr/src/libnetconf; \
+    ./configure --prefix='/usr'; \
+    make; \
+    make install; \
+    ln -s /usr/lib/pkgconfig/libnetconf.pc /usr/lib64/pkgconfig/
+
+## build and install netopeer-server
+COPY server /usr/src/netopeer/server
+RUN set -e -x; \
+    cd /usr/src/netopeer/server; \
+    ./configure --prefix='/usr'; \
+    make; \
+    make install
+
+CMD ["/usr/bin/netopeer-server", "-v", "2"]
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ As part of the Netopeer server, there is a set of the following tools:
  * [netopeer-manager(1)](http://netopeer.googlecode.com/git/server/manager/netopeer-manager.1.html)
  * [netopeer-configurator(1)](http://netopeer.googlecode.com/git/server/configurator/netopeer-configurator.1.html)
 
+#### Running the server in docker
+
+This repository has a `Dockerfile` that can be used to create a container that
+builds netopeer-server and starts the service. You need a linux with
+working [docker](https://www.docker.com/) installation to use it.
+
+To build the container:
+~~~
+docker build -t netopeer .
+~~~
+
+To start it:
+~~~
+docker run -it --rm -p 8300:830 --name netopeer netopeer
+~~~
+
+The line above maps netopeer's netconf port to 8300 on the host. You can
+connect to that port with [ncclient](https://github.com/ncclient/ncclient)
+without any user or password (as long as you have a valid private key on the
+host).
+
 ### [TransAPI modules](./transAPI)
 
 Netopeer projects provides several basic transAPI modules that, besides their


### PR DESCRIPTION
- Add a Dockerfile that creates a container based on the latest CentOS,
  builds and installs libnetconf and netopeer on it and allows the user
  to test the software without having to deal with dependencies and
  versions.
- Update README.md with docker usage.
- .travis.yml: travis CI configuration that builds the container and
  uses ncclient to perform a get operation using netconf.