### PR TITLE
docker: compile and install transAPI/cfgsystem in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM centos
+FROM centos:7
 
 # install required packages
 RUN ["yum", "install", "-y", "epel-release"]
-RUN ["yum", "install", "-y", "git", "make", "libtool", "libxml2-devel", "file", "libxslt-devel", "libssh-devel", "libcurl-devel", "python-pip", "libxml2-python", "openssh-server" ]
+RUN ["yum", "install", "-y", "git", "make", "libtool", "libxml2-devel", "file", "libxslt-devel", "libssh-devel", "libcurl-devel", "python-pip", "libxml2-python", "openssh-server", "augeas-devel" ]
 RUN ["ssh-keygen", "-A"]
 RUN ["pip", "install", "pyang"]
 
@@ -15,13 +15,25 @@ RUN set -e -x; \
     make install; \
     ln -s /usr/lib/pkgconfig/libnetconf.pc /usr/lib64/pkgconfig/
 
-## build and install netopeer-server
+# build and install netopeer-server
 COPY server /usr/src/netopeer/server
 RUN set -e -x; \
     cd /usr/src/netopeer/server; \
     ./configure --prefix='/usr'; \
     make; \
-    make install
+    make install; \
+    cp -v config/datastore.xml /usr/etc/netopeer/cfgnetopeer/datastore.xml
+
+# build and install transAPI/cfgsystem
+COPY transAPI/cfgsystem /usr/src/netopeer/cfgsystem
+RUN set -e -x; \
+    cd /usr/src/netopeer/cfgsystem; \
+    ./configure --prefix='/usr'; \
+    make; \
+    make install; \
+    sed -i '/<hostname>/d' /usr/etc/netopeer/ietf-system/datastore.xml
 
 CMD ["/usr/bin/netopeer-server", "-v", "2"]
 
+# expose ports
+EXPOSE 830


### PR DESCRIPTION
- Copy the configuration example form the repository to the container.
- Remove hostname configuration, as it doesn't work in docker.
- Expose port 830.
